### PR TITLE
8.9.2 fixup

### DIFF
--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -1,8 +1,8 @@
 #!/bin/bash
 
-# Copy all the header files and the shared libraries, but not the static libraries, into the prefix
+# Copy all the header files and the shared libraries (including symlinks), but not the static libraries, into the prefix
 mkdir -p $PREFIX/include
 cp include/* $PREFIX/include/
 
 mkdir -p $PREFIX/lib
-cp lib/libcudnn*so* $PREFIX/lib/
+cp --no-dereference lib/libcudnn*so* $PREFIX/lib/

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,8 +1,9 @@
 {% set cudnn_version= "8.9.2.26" %}
 {% set build_number= "0" %}
 # The cuDNN installers can be downloaded from https://developer.nvidia.com/rdp/cudnn-download
-# The download requires authentication, for this recipe to work download the
-# packages to a local location and adjust src_dir to this location.
+# The download requires a manual sign-in to Nvidia's website. For this recipe to work, download the
+# packages to a local location and adjust src_dir to this location. Remember to escape backslashes
+# (i.e., on Windows).
 {% set src_dir = "file:///home/builder/nvidia" %}
 
 package:


### PR DESCRIPTION
The previous recipe was resolving the symlinks to the real libraries during copy, resulting in a ~2 GB package. This reduces it to about 600 MB. Changes are

- Fix symlinks resolving into real files on copy
- improve notes around the manual download

Build number is not incremented as I hadn't already uploaded v8.9.2.