### PR TITLE
Pkg 4598 cuda 12

### DIFF
--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -1,4 +1,4 @@
 cuda_maj_version:
-- 11
+# - 11
 # We don't have cudatoolkit v12 packaged yet - uncomment this line when we have.
-# - 12
+ - 12

--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -1,4 +1,3 @@
 cuda_maj_version:
 # - 11
-# We don't have cudatoolkit v12 packaged yet - uncomment this line when we have.
  - 12

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -38,13 +38,23 @@ requirements:
     - libcublas                              # [cuda_maj_version == 12]
 
 test:
+  requires:
+    - {{ compiler('c') }}                                                                                        # [linux and x86_64]
+  files:
+    - test_load_elf.c                                                                                            # [linux and x86_64]
   commands:
-    - test -f ${PREFIX}/lib/libcudnn.so                                                             # [linux and x86_64]
-    - test -f ${PREFIX}/lib/libcudnn.so.{{ '.'.join(cudnn_version.split('.')[0:1]) }}               # [linux and x86_64]
-    - test -f ${PREFIX}/lib/libcudnn.so.{{ '.'.join(cudnn_version.split('.')[0:3]) }}               # [linux and x86_64]
-    - test -f ${PREFIX}/include/cudnn.h                                                             # [linux and x86_64]
-    - if not exist %LIBRARY_INC%\\cudnn.h exit 1                                                    # [win and x86_64]
-    - if not exist %LIBRARY_BIN%\\cudnn64_{{ '.'.join(cudnn_version.split('.')[0:1]) }}.dll exit 1  # [win and x86_64]
+    - if not exist %LIBRARY_INC%\\cudnn.h exit 1                                                                 # [win]
+    - if not exist %LIBRARY_INC%\\cudnn_adv_train.h exit 1                                                       # [win]
+    - if not exist %LIBRARY_BIN%\\cudnn64_{{ '.'.join(cudnn_version.split('.')[0:1]) }}.dll exit 1               # [win]
+    - if not exist %LIBRARY_BIN%\\cudnn_adv_train64_{{ '.'.join(cudnn_version.split('.')[0:1]) }}.dll exit 1     # [win]
+    - test -f ${PREFIX}/include/cudnn.h                                                                          # [linux and x86_64]
+    - test -f ${PREFIX}/include/cudnn_adv_train.h                                                                # [linux and x86_64]
+    - test -f ${PREFIX}/lib/libcudnn.so                                                                          # [linux and x86_64]
+    - test -f ${PREFIX}/lib/libcudnn_adv_train.so                                                                # [linux and x86_64]
+    - test -f ${PREFIX}/lib/libcudnn.so.{{ '.'.join(cudnn_version.split('.')[0:1]) }}                            # [linux and x86_64]
+    - test -f ${PREFIX}/lib/libcudnn.so.{{ '.'.join(cudnn_version.split('.')[0:3]) }}                            # [linux and x86_64]
+    - ${GCC} test_load_elf.c -std=c99 -Werror -ldl -o test_load_elf                                              # [linux and x86_64]
+    - for f in ${PREFIX}/lib/libcudnn*.so; do ./test_load_elf $f; done                                           # [linux and x86_64]
 
 about:
   home: https://developer.nvidia.com/cudnn

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -27,7 +27,10 @@ build:
 
 requirements:
   run:
-    - cudatoolkit {{ cuda_maj_version }}
+    - cudatoolkit {{ cuda_maj_version }}.*   # [cuda_maj_version == 11]
+    - cuda-version {{ cuda_maj_version }}.*
+    - cuda-nvrtc                             # [cuda_maj_version == 12]
+    - libcublas                              # [cuda_maj_version == 12]
 
 test:
   commands:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -36,6 +36,8 @@ requirements:
     - cuda-version {{ cuda_maj_version }}.*
     - cuda-nvrtc                             # [cuda_maj_version == 12]
     - libcublas                              # [cuda_maj_version == 12]
+    # libcudnn_cnn_infer.so needs libm.so.6 with ABI v2.27
+    - __glibc >=2.27                         # [linux and aarch64]
 
 test:
   requires:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,23 +1,28 @@
 {% set cudnn_version= "8.9.2.26" %}
 {% set build_number= "0" %}
-# The cuDNN installers can be downloaded from https://developer.nvidia.com/rdp/cudnn-download
-# The download requires a manual sign-in to Nvidia's website. For this recipe to work, download the
-# packages to a local location and adjust src_dir to this location. Remember to escape backslashes
-# (i.e., on Windows).
-{% set src_dir = "file:///home/builder/nvidia" %}
+{% set platform = "linux-x86_64" %}  # [linux64]
+{% set platform = "linux-ppc64le" %}  # [ppc64le]
+{% set platform = "linux-sbsa" %}  # [aarch64]
+{% set platform = "windows-x86_64" %}  # [win]
+{% set extension = "tar.xz" %}  # [not win]
+{% set extension = "zip" %}  # [win]
+
 
 package:
   name: cudnn
   version: {{ cudnn_version }}
 
 source:
-  url: {{ src_dir }}/cudnn-linux-x86_64-{{ cudnn_version }}_cuda{{ cuda_maj_version }}-archive.tar.xz     # [linux and x86_64]
-  sha256: 39883d1bcab4bd2bf3dac5a2172b38533c1e777e45e35813100059e5091406f6                                # [linux and x86_64]
-  url: {{ src_dir }}/cudnn-windows-x86_64-{{ cudnn_version }}_cuda{{ cuda_maj_version }}-archive.zip      # [win and x86_64]
-  sha256: d3daa2297917333857eaaba1213dd9fc05c099d94e88663274a0f37a4e9baf9d                                # [win and x86_64]
+  url: https://developer.download.nvidia.com/compute/cudnn/redist/cudnn/{{ platform }}/cudnn-{{ platform }}-{{ cudnn_version }}_cuda{{ cuda_maj_version }}-archive.{{ extension }}
+  sha256: 39883d1bcab4bd2bf3dac5a2172b38533c1e777e45e35813100059e5091406f6  # [linux64 and (cuda_maj_version == 11)]
+  sha256: ccafd7d15c2bf26187d52d79d9ccf95104f4199980f5075a7c1ee3347948ce32  # [linux64 and (cuda_maj_version == 12)]
+  sha256: ad0a45a7992fe165fef3c8be5eef4080ebad19a2334c29dfb01d605776927293  # [aarch64 and (cuda_maj_version == 11)]
+  sha256: 898d00c82f9ad8797bd6f6c639327b320a38fa4aeebfb2b3fbb2db0d38f7e1b0  # [aarch64 and (cuda_maj_version == 12)]
+  sha256: d3daa2297917333857eaaba1213dd9fc05c099d94e88663274a0f37a4e9baf9d  # [win and (cuda_maj_version == 11)]
+  sha256: 8cf26fec7362d7fac110df9986a579e932a7e1ae693a11e3fa77cca41ae4d8b9  # [win and (cuda_maj_version == 12)]
 
 build:
-  skip: True  # [not (linux and x86_64) and not (win and x86_64)]
+  skip: True  # [osx or (linux and s390x)]
   number: {{ build_number }}
   string: cuda{{ cuda_maj_version }}_{{ build_number }}
   missing_dso_whitelist:

--- a/recipe/test_load_elf.c
+++ b/recipe/test_load_elf.c
@@ -1,0 +1,25 @@
+#include <stdio.h>
+#include <stdlib.h>
+#include <dlfcn.h>
+
+int main(int argc, char** argv) {
+    void* handle;
+    char* full_lib;
+
+    if (argc != 2) {
+        fprintf(stderr, "usage: test_load_elf mylib.so\n");
+        exit(EXIT_FAILURE);
+    }
+    full_lib = argv[1];
+
+    handle = dlopen(full_lib, RTLD_NOW);
+    if (!handle) {
+        fprintf(stderr, "error: %s\n", dlerror());
+        exit(EXIT_FAILURE);
+    } else {
+        printf("success: %s\n", full_lib);
+        dlclose(handle);
+    }
+
+    return EXIT_SUCCESS;
+}


### PR DESCRIPTION
**Destination channel:** defaults

### Links

- [PKG-4598](https://anaconda.atlassian.net/browse/PKG-4598)

### Explanation of changes:

- Update to support CUDA 12. see commit messages for changes and explanation
- Version not updated, adding a new variant, therefore build number not bumped

[PKG-4598]: https://anaconda.atlassian.net/browse/PKG-4598?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ