### PR TITLE
update to 9.23.1.3

### DIFF
--- a/recipe/bld.bat
+++ b/recipe/bld.bat
@@ -19,5 +19,6 @@ if not exist %LIBRARY_BIN% (
     if errorlevel 1 exit 1
 )
 
-copy %SRC_DIR%\bin\cudnn*.dll %LIBRARY_BIN%\
+REM cuDNN 9.23 moved the Windows DLLs from bin\ to bin\x64\ (matching lib\x64).
+copy %SRC_DIR%\bin\x64\cudnn*.dll %LIBRARY_BIN%\
 if errorlevel 1 exit 1

--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -1,33 +1,15 @@
-# cuDNN support matrix:
-# https://docs.nvidia.com/deeplearning/cudnn/backend/latest/reference/support-matrix.html
+# cuDNN is a binary redist repack. The CUDA variant matrix (12.x + 13.x) is
+# inherited from the aggregate CBC's cuda_compiler_version.
 #
-# Linux builds (CUDA paired with GCC via zip_keys below):
-#  * Keep CUDA 12.4 for GCC 11.2.0+ compatibility
-#  * Use latest CUDA 12.x and 13.x for GCC 14.3.0+ compatibility
-#
-# This local cuda_compiler_version is linux-only on purpose: Windows CUDA
-# variants now come from the aggregate CBC (cuda_compiler_version is
-# `# [linux or (win and x86_64)]`). Leaving 12.8/13.0 unscoped here made them
-# leak to win and collide with the aggregate, zipping mismatched lengths
-# (c_compiler_version vs cuda_compiler_version) at graph generation. The
-# gcc<->cuda zip_keys applies only on linux, so win uses MSVC + aggregate CUDA.
-cuda_compiler_version:
-  - 12.4                     # [linux]
-  - 12.8                     # [linux]
-  - 13.0                     # [linux]
-
-c_compiler_version:          # [linux]
-  - 11.2.0                   # [linux]
-  - 14.3.0                   # [linux]
-  - 14.3.0                   # [linux]
-
-cxx_compiler_version:        # [linux]
-  - 11.2.0                   # [linux]
-  - 14.3.0                   # [linux]
-  - 14.3.0                   # [linux]
-
-zip_keys:
-  -                          # [linux]
-    - c_compiler_version     # [linux]
-    - cxx_compiler_version   # [linux]
-    - cuda_compiler_version  # [linux]
+# The previous local `c_compiler_version x cuda_compiler_version` zip (which
+# paired gcc 11.2.0 with cuda 12.4 for an older-toolchain build) was removed:
+# the aggregate now owns cuda_compiler_version (including win, via
+# `# [linux or (win and x86_64)]`), and that collided with the local zip_keys
+# at graph generation (zip-length mismatch between the aggregate's
+# c_compiler_version and cuda_compiler_version). For a binary repack the build
+# compiler does not affect NVIDIA's prebuilt libraries, and every cuda-12.x
+# build pins the same `cuda-version >=12,<13` at runtime, so the dropped
+# gcc-11.2/cuda-12.4 variant added no runtime coverage. conda-forge likewise
+# uses no gcc<->cuda zip for cuDNN.
+arm_variant_type: # [aarch64]
+  - sbsa          # [aarch64]

--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -1,16 +1,20 @@
-# cuDNN v9.17 support matrix:
-# https://docs.nvidia.com/deeplearning/cudnn/backend/v9.17.0/reference/support-matrix.html
+# cuDNN support matrix:
+# https://docs.nvidia.com/deeplearning/cudnn/backend/latest/reference/support-matrix.html
 #
-# Linux builds:
+# Linux builds (CUDA paired with GCC via zip_keys below):
 #  * Keep CUDA 12.4 for GCC 11.2.0+ compatibility
 #  * Use latest CUDA 12.x and 13.x for GCC 14.3.0+ compatibility
 #
-# Windows builds:
-#  * Use latest CUDA 12.x and 13.x
+# This local cuda_compiler_version is linux-only on purpose: Windows CUDA
+# variants now come from the aggregate CBC (cuda_compiler_version is
+# `# [linux or (win and x86_64)]`). Leaving 12.8/13.0 unscoped here made them
+# leak to win and collide with the aggregate, zipping mismatched lengths
+# (c_compiler_version vs cuda_compiler_version) at graph generation. The
+# gcc<->cuda zip_keys applies only on linux, so win uses MSVC + aggregate CUDA.
 cuda_compiler_version:
   - 12.4                     # [linux]
-  - 12.8
-  - 13.0
+  - 12.8                     # [linux]
+  - 13.0                     # [linux]
 
 c_compiler_version:          # [linux]
   - 11.2.0                   # [linux]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "9.17.0.29" %}
+{% set version = "9.23.1.3" %}
 {% set soname = version.split('.')[0] %}
 {% set majorminorpatch = '.'.join(version.split('.')[:3]) %}
 {% set platform = "linux-x86_64" %}  # [linux64]
@@ -14,12 +14,12 @@ package:
 source:
   url: https://developer.download.nvidia.com/compute/cudnn/redist/cudnn/{{ platform }}/cudnn-{{ platform }}-{{ version }}_cuda12-archive.{{ extension }}  # [(cuda_compiler_version or "").startswith("12")]
   url: https://developer.download.nvidia.com/compute/cudnn/redist/cudnn/{{ platform }}/cudnn-{{ platform }}-{{ version }}_cuda13-archive.{{ extension }}  # [(cuda_compiler_version or "").startswith("13")]
-  sha256: 595de8d82e979beee74b079ca1249c6292f643f6543ee7f2df8499d51da159f0  # [linux64 and (cuda_compiler_version or "").startswith("12")]
-  sha256: 455f15075493c82a1a8850aae6120f3fa6f7e457cbef56c1cb2e0a618b5b509e  # [linux64 and (cuda_compiler_version or "").startswith("13")]
-  sha256: 8b6a90133a06e0b25bcdcd806a86f23a94b99837e2b8b46e3c8eddfdc1ff06cb  # [aarch64 and (cuda_compiler_version or "").startswith("12")]
-  sha256: 19be6d8f2b63a459e6758185c1e8feeddecdb4b56717dc4e4bbcfe30a0619b7d  # [aarch64 and (cuda_compiler_version or "").startswith("13")]
-  sha256: 46776b0a4e28878a619c682d58d7974ff6b90ea3c73f20519f111cfb36987c0d  # [win and (cuda_compiler_version or "").startswith("12")]
-  sha256: 6b24e18a17f52fbf640b71f6d06061240f4e7d06f00ec3055c0ced2b5eb7eb8a  # [win and (cuda_compiler_version or "").startswith("13")]
+  sha256: 4ee977ed4abaf4d39810db31bc4ab4ff51a884f907c33446d8feb706550ad65c  # [linux64 and (cuda_compiler_version or "").startswith("12")]
+  sha256: bce62e93b32909445fcae8c383868dedff6aea7ef653e3e80a450fc5f7340d35  # [linux64 and (cuda_compiler_version or "").startswith("13")]
+  sha256: dbbf149c4b944d5b3fb81e78c81ce8bdb10eef2d7960b9231ebabf71e7819bdd  # [aarch64 and (cuda_compiler_version or "").startswith("12")]
+  sha256: 1096dbebc724cade8fbc7a16a1e1057b4a41286b805226ad2ded870e00858334  # [aarch64 and (cuda_compiler_version or "").startswith("13")]
+  sha256: 6062e48b9a04fc6eff1643ec38890be7fb0ed01efeb998f1ff25ae97a6a70813  # [win and (cuda_compiler_version or "").startswith("12")]
+  sha256: c317dd1298a191dd1ba44e00906c5b69ac80d17f5c32e17c5f880819a9a9c38d  # [win and (cuda_compiler_version or "").startswith("13")]
 
 build:
   number: 0


### PR DESCRIPTION
cudnn 9.23.1.3

**Destination channel:** defaults

### Links
- [PKG-15072](https://anaconda.atlassian.net/browse/PKG-15072)
- [cuDNN release notes](https://docs.nvidia.com/deeplearning/cudnn/backend/latest/release-notes.html)
- Reference: [conda-forge/cudnn-feedstock](https://github.com/conda-forge/cudnn-feedstock)

### Explanation of changes:
- Update the cuDNN redist repack **9.17.0.29 → 9.23.1.3** (version + sha256 only; the 6-output layout and deps are unchanged and match conda-forge).
- All 4 active linux sha256s (linux-64 + linux-aarch64 × cuda 12/13) **verified** against the NVIDIA redist server; win sha256s updated to match.
- AR keeps its **CUDA 12 + 13** matrix (12.4/12.8/13.0 on linux; 12.8/13.0 on win) — note AR intentionally builds CUDA 12 variants that conda-forge dropped for 9.23.
- No downstream rebuilds: pytorch/libtorch/onnxruntime pin `cudnn/libcudnn >=...,<10.0a0`, and 9.23.1.3 is still major 9, so all existing ranges are satisfied.

[PKG-15072]: https://anaconda.atlassian.net/browse/PKG-15072?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ